### PR TITLE
Potential fix for code scanning alert no. 1: Exception text reinterpreted as HTML

### DIFF
--- a/app/api/register/route.ts
+++ b/app/api/register/route.ts
@@ -1,6 +1,7 @@
 import bcrypt from 'bcrypt';
 import prisma from '@/app/libs/prismadb';
 import { NextResponse } from 'next/server';
+import he from 'he';
 
 export async function POST(request: Request) {
   try {
@@ -35,6 +36,7 @@ export async function POST(request: Request) {
     }
 
     // return error
-    return new NextResponse(error.message, { status: 500 });
+    const safeMessage = he.encode(error.message || 'An unexpected error occurred');
+    return new NextResponse(safeMessage, { status: 500 });
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "react-spinners": "^0.13.8",
     "tailwindcss": "3.3.3",
     "typescript": "5.1.6",
-    "zustand": "^4.4.1"
+    "zustand": "^4.4.1",
+    "he": "^1.2.0"
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.0",


### PR DESCRIPTION
Potential fix for [https://github.com/Adilmunawar/Nexsus-Chat/security/code-scanning/1](https://github.com/Adilmunawar/Nexsus-Chat/security/code-scanning/1)

To fix the issue, we need to sanitize or escape the `error.message` before including it in the HTTP response. A safe approach is to use a library like `he` (HTML entities) to encode the error message, ensuring that any special characters are properly escaped. This prevents the browser from interpreting the error message as HTML or JavaScript.

The changes will involve:
1. Importing the `he` library for HTML encoding.
2. Encoding `error.message` before including it in the response on line 38.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
